### PR TITLE
Reducing binary size

### DIFF
--- a/SDK/include/AK/Tools/Common/AkHashList.h
+++ b/SDK/include/AK/Tools/Common/AkHashList.h
@@ -42,9 +42,9 @@ template < class T_KEY >
 AkForceInline AkHashType AkHash(T_KEY in_key) { return (AkHashType)in_key; }
 
 #define AK_HASH_SIZE_VERY_SMALL 11
-static const AkHashType kHashSizes[] = { 29, 53, 97, 193, 389, 769, 1543, 3079, 6151, 12289, 24593, 49157, 98317, 196613, 393241, 786433, 1572869, 3145739, 6291469, 12582917, 25165843, 50331653, 100663319, 201326611, 402653189, 805306457, 1610612741 };
-static const size_t kNumHashSizes = sizeof(kHashSizes) / sizeof(kHashSizes[0]);
-static const AkReal32 kHashTableGrowthFactor = 0.9f; 
+inline constexpr AkHashType kHashSizes[] = { 29, 53, 97, 193, 389, 769, 1543, 3079, 6151, 12289, 24593, 49157, 98317, 196613, 393241, 786433, 1572869, 3145739, 6291469, 12582917, 25165843, 50331653, 100663319, 201326611, 402653189, 805306457, 1610612741 };
+inline constexpr size_t kNumHashSizes = sizeof(kHashSizes) / sizeof(kHashSizes[0]);
+inline constexpr AkReal32 kHashTableGrowthFactor = 0.9f; 
 
 template < class T_KEY, class T_ITEM, typename T_ALLOC = ArrayPoolDefault >
 class AkHashList: public T_ALLOC


### PR DESCRIPTION
Situation:

These constants are defined in a header file and declared static, which results in internal linkage, increasing binary size (a few KB).

Solution:

Forcing external linkage with inline keyword